### PR TITLE
migrate to modern GitHub issue-template workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,24 +1,44 @@
-<!--
-NOTE: IF YOU HAVE ANY PROBLEMS DURING THE INSTALLATION PLEASE VISIT OUR COMMUNITY FORUM AND POST YOUR DETAILED QUESTION THERE:  https://community.kobotoolbox.org/c/kobo-install. Due to the small size of our team and large volume of users, we cannot provide support or guidance via GitHub issues. Please only create an issue for reporting an actual bug in the installation script
--->
-<!-- IMPORTANT: Do NOT share any confidential information (such as user credentials) in this issue! -->
-
-**Description**
-<!-- A clear and concise description of what the bug is. Provide logs and `.run.conf`. -->
-
-**Steps to Reproduce**
-<!-- Steps to reproduce the behavior -->
-
-**Expected behavior**
-<!--- A clear and concise description of what you expected to happen. -->
-
-**Desktop**
-<!-- (please complete the following information): -->
-
- - OS:
- - Python Version:
- - Docker Version:
- - Docker Compose Version:
-
-**Additional context**
-<!-- Add any other context about the problem here. -->
+name: Bug report
+description: Create a report to help us improve KoBo Docker
+title: "[Bug]: "
+labels: ["bug"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Thanks for taking the time to file a bug!**  
+        Please fill out every required field to help us reproduce.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      placeholder: Clear and concise description of the problem…
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      placeholder: 1. … 2. …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      placeholder: What you expected to happen
+  - type: textarea
+    id: desktop
+    attributes:
+      label: Desktop / Server Details
+      placeholder: |
+        OS:
+        Docker version:
+        Docker-compose version:
+        KoBo-docker release/tag:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      placeholder: Paste relevant logs or screenshots here


### PR DESCRIPTION
Replaces outdated ISSUE_TEMPLATE.md with YAML workflow templates for bug reports it improves consistency and aligns with github standards